### PR TITLE
Add refined stage control notebooks

### DIFF
--- a/stage_mv_linux.ipynb
+++ b/stage_mv_linux.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thorlabs Stage Movement Example (Linux)\n",
+    "Demonstrates stage control using the Kinesis SDK on Linux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import clr\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "kinesis_path = '/opt/Thorlabs/Kinesis'\n",
+    "sys.path.append(kinesis_path)\n",
+    "os.environ['LD_LIBRARY_PATH'] = os.environ.get('LD_LIBRARY_PATH', '') + ':' + kinesis_path\n",
+    "\n",
+    "clr.AddReference(os.path.join(kinesis_path, 'Thorlabs.MotionControl.DeviceManagerCLI.dll'))\n",
+    "clr.AddReference(os.path.join(kinesis_path, 'Thorlabs.MotionControl.KCube.DCServoCLI.dll'))\n",
+    "\n",
+    "from Thorlabs.MotionControl.DeviceManagerCLI import DeviceManagerCLI\n",
+    "from Thorlabs.MotionControl.KCube.DCServoCLI import KCubeDCServo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "DeviceManagerCLI.BuildDeviceList()\n",
+    "serial_no = 'YOUR_SERIAL_NO'\n",
+    "\n",
+    "motor = KCubeDCServo.CreateKCubeDCServo(serial_no)\n",
+    "motor.Connect(serial_no)\n",
+    "\n",
+    "if not motor.IsConnected:\n",
+    "    raise RuntimeError('Failed to connect to device')\n",
+    "\n",
+    "motor.WaitForSettingsInitialized(5000)\n",
+    "motor.StartPolling(250)\n",
+    "motor.EnableDevice()\n",
+    "motor.Home(60000)\n",
+    "motor.WaitForMoveToComplete(60000)\n",
+    "print('Homing complete')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "start_pos = motor.Position\n",
+    "print(f'Current position: {start_pos} mm')\n",
+    "\n",
+    "target = start_pos + 1.0\n",
+    "motor.MoveTo(target, 60000)\n",
+    "motor.WaitForMoveToComplete(60000)\n",
+    "\n",
+    "end_pos = motor.Position\n",
+    "print(f'Moved to: {end_pos} mm')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "motor.StopPolling()\n",
+    "motor.Disconnect()\n",
+    "print('Device disconnected')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/state_mv.ipynb
+++ b/state_mv.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thorlabs Stage Movement\n",
+    "Example code to move a stage using the Kinesis SDK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import clr\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# Update this path to the Kinesis installation\n",
+    "kinesis_path = r'C:\\Program Files\\Thorlabs\\Kinesis'\n",
+    "sys.path.append(kinesis_path)\n",
+    "os.environ['PATH'] += ';' + kinesis_path\n",
+    "\n",
+    "clr.AddReference(os.path.join(kinesis_path, 'Thorlabs.MotionControl.DeviceManagerCLI.dll'))\n",
+    "clr.AddReference(os.path.join(kinesis_path, 'Thorlabs.MotionControl.KCube.DCServoCLI.dll'))\n",
+    "\n",
+    "from Thorlabs.MotionControl.DeviceManagerCLI import DeviceManagerCLI\n",
+    "from Thorlabs.MotionControl.KCube.DCServoCLI import KCubeDCServo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "DeviceManagerCLI.BuildDeviceList()\n",
+    "serial_no = 'YOUR_SERIAL_NO'\n",
+    "\n",
+    "motor = KCubeDCServo.CreateKCubeDCServo(serial_no)\n",
+    "motor.Connect(serial_no)\n",
+    "\n",
+    "if not motor.IsConnected:\n",
+    "    raise RuntimeError('Failed to connect to device')\n",
+    "\n",
+    "motor.WaitForSettingsInitialized(5000)\n",
+    "motor.StartPolling(250)\n",
+    "motor.EnableDevice()\n",
+    "motor.Home(60000)\n",
+    "motor.WaitForMoveToComplete(60000)\n",
+    "print('Homing complete')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "start_pos = motor.Position\n",
+    "print(f'Current position: {start_pos} mm')\n",
+    "\n",
+    "target = start_pos + 1.0  # move 1 mm forward\n",
+    "motor.MoveTo(target, 60000)\n",
+    "motor.WaitForMoveToComplete(60000)\n",
+    "\n",
+    "end_pos = motor.Position\n",
+    "print(f'Moved to: {end_pos} mm')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "motor.StopPolling()\n",
+    "motor.Disconnect()\n",
+    "print('Device disconnected')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- refine Linux stage movement example
- update stage movement notebook with position checks and clean disconnect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c9856732483319a6972be47448ad1